### PR TITLE
fixed that pressure_rate was not set in specific cases

### DIFF
--- a/xensiv_dps3xx.c
+++ b/xensiv_dps3xx.c
@@ -678,8 +678,8 @@ cy_rslt_t xensiv_dps3xx_set_config(xensiv_dps3xx_t* dev, xensiv_dps3xx_config_t*
                                                    config->temperature_rate);
     }
     if ((CY_RSLT_SUCCESS == rc) &&
-        ((config->pressure_rate != dev->user_config.temperature_rate) ||
-         (config->pressure_oversample != dev->user_config.temperature_oversample)))
+        ((config->pressure_rate != dev->user_config.pressure_rate) ||
+         (config->pressure_oversample != dev->user_config.pressure_oversample)))
     {
         rc = _xensiv_dps3xx_set_pressure_config(dev, config->pressure_oversample,
                                                 config->pressure_rate);


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Current code compares config set by the user for pressure with the settings for temperature. When they match, the user settings won't be done. It looks like a copy&paste error from the temperature config in line 673.
e.g. if user sets config.pressure_rate = XENSIV_DPS3XX_RATE_128 and config.temperature_rate = XENSIV_DPS3XX_RATE_128 the pressure setting is not set in the sensor.

Context
```C
xensiv_dps3xx_config_t config = {
    .dev_mode = XENSIV_DPS3XX_MODE_BACKGROUND_ALL,
    .pressure_rate = XENSIV_DPS3XX_RATE_128,
    .temperature_rate = XENSIV_DPS3XX_RATE_128,
    .pressure_oversample = XENSIV_DPS3XX_OVERSAMPLE_1,
    .temperature_oversample = XENSIV_DPS3XX_OVERSAMPLE_1,
    .interrupt_triggers = XENSIV_DPS3XX_INT_NONE,
    .fifo_enable = false,
    .data_timeout = 10,
    .i2c_timeout = 10
};

/* Configure the available sensors */
for (uint8_t iSensor=0; iSensor<nSensors; iSensor++)
{
    result = xensiv_dps3xx_set_config(&vAvailableSensors[iSensor], &config);
    CY_ASSERT(result == CY_RSLT_SUCCESS);
}
```
```Makefile
TARGET=APP_CY8CPROTO-062S2-43439
```
Protocol: I2C