### PR TITLE
Fixing timeout bug

### DIFF
--- a/xensiv_dps3xx.c
+++ b/xensiv_dps3xx.c
@@ -600,7 +600,7 @@ cy_rslt_t xensiv_dps3xx_init_i2c(xensiv_dps3xx_t* obj, const xensiv_dps3xx_i2c_c
         }
         obj->comm.delay(10);
         timeout -= 10;
-    } while (0L >= timeout);
+    } while (timeout > 0L);
 
     // read calibration coefficients
     if (rc == CY_RSLT_SUCCESS)


### PR DESCRIPTION
Original statement was the negated version of the correct statement. A mistake happened.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Statement in do-while loop condition was negated. Timeout did not work as expected. In previous behaviour timeout was always 10ms via magic number and faulty logic. Fixed with a simple change.

Related Issue
./.

Context
No context needed. This is a logical mistake.